### PR TITLE
Caching fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     with:
       ruby-version: ${{ inputs.ruby-version }}
       bundler-cache: true
-      cache-version: ${{ inputs.rails-version }}-${{ inputs.solidus-branch }}
+      cache-version: ${{ inputs.rails-version }}-${{ inputs.solidus-branch }}-{{ inputs.database }}-{{ inputs.ruby-version }}
       rubygems: "latest"
   - name: Restore apt cache
     id: apt-cache


### PR DESCRIPTION

## Summary

We were getting a lot of warnings because the bundler cache is "already present". This likely has to do with the fact that prior to this commit, not all inputs were present in the cache key for the bundler cache.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
