### PR TITLE
fix: Testing database adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The action automatically sets the correct `DB_USERNAME` based on the database:
 
 Configure your database services with passwordless access for simplicity (see example below).
 
+> [!WARNING]
+> Rails 8.0 has a [known issue](https://github.com/rails/rails/issues/53673) with MySQL/MariaDB that causes empty `Mysql2::Error` messages. Until a fix is released, exclude the `mariadb` + Rails 8.0 combination from your test matrix.
+
 ## Example configuration
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 A GitHub action for testing Solidus extensions
 
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `ruby-version` | Ruby version to use | Yes | `3.3` |
+| `rails-version` | Rails version to use | Yes | `7.2` |
+| `solidus-branch` | Solidus branch to use | Yes | `main` |
+| `database` | Database to use (`sqlite`, `postgresql`, `mysql`, or `mariadb`) | Yes | `sqlite` |
+
+## Database Services
+
+This is a composite GitHub Action, which means it **cannot define services directly**. If you need to test against PostgreSQL or MySQL/MariaDB, you must define the database service in your workflow file.
+
+The action will install the necessary database client libraries automatically based on the `database` input.
+
+### Database Credentials
+
+The action automatically sets the correct `DB_USERNAME` based on the database:
+
+- **PostgreSQL**: `postgres` (default superuser)
+- **MySQL/MariaDB**: `root` (default superuser)
+
+Configure your database services with passwordless access for simplicity (see example below).
+
 ## Example configuration
 
 ```yaml
@@ -26,6 +50,29 @@ jobs:
   rspec:
     name: Solidus ${{ matrix.solidus-branch }}, Rails ${{ matrix.rails-version }} and Ruby ${{ matrix.ruby-version }} on ${{ matrix.database }}
     runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 5432:5432
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 3306:3306
     strategy:
       fail-fast: true
       matrix:

--- a/action.yml
+++ b/action.yml
@@ -41,59 +41,59 @@ services:
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v4
-  - name: Set up Ruby
-    uses: ruby/setup-ruby@v1
-    env:
-      RAILS_VERSION: ${{ inputs.rails-version }}
-      SOLIDUS_BRANCH: ${{ inputs.solidus-branch }}
-    with:
-      ruby-version: ${{ inputs.ruby-version }}
-      bundler-cache: true
-      cache-version: ${{ inputs.rails-version }}-${{ inputs.solidus-branch }}-{{ inputs.database }}-{{ inputs.ruby-version }}
-      rubygems: "latest"
-  - name: Restore apt cache
-    id: apt-cache
-    uses: actions/cache@v4
-    with:
-      path: /home/runner/apt/cache
-      key: ${{ runner.os }}-apt-${{ inputs.database }}
-      restore-keys: |
-        ${{ runner.os }}-apt-
-  - name: Install libvips
-    shell: bash
-    run: |
-      mkdir -p /home/runner/apt/cache
-      sudo apt update -qq
-      sudo apt install -qq --fix-missing libvips -o dir::cache::archives="/home/runner/apt/cache"
-      sudo chown -R runner /home/runner/apt/cache
-  - name: Install Postgres headers
-    if: inputs.database == 'postgresql'
-    shell: bash
-    run: |
-      mkdir -p /home/runner/apt/cache
-      sudo apt update -qq
-      sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
-      sudo chown -R runner /home/runner/apt/cache
-  - name: Install MariaDB headers
-    if: inputs.database == 'mariadb'
-    shell: bash
-    run: |
-      mkdir -p /home/runner/apt/cache
-      sudo apt update -qq
-      sudo apt install -qq --fix-missing libmysqlclient-dev -o dir::cache::archives="/home/runner/apt/cache"
-      sudo chown -R runner /home/runner/apt/cache
-  - name: Run tests
-    shell: bash
-    env:
-      RAILS_VERSION: ${{ inputs.rails-version }}
-      SOLIDUS_BRANCH: ${{ inputs.solidus-branch }}
-    run: |
-      bundle exec rake
-  - uses: actions/upload-artifact@v4
-    if: failure()
-    with:
-      name: Screenshots
-      path: |
-        spec/dummy/tmp/capybara
-        spec/dummy/tmp/screenshots
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      env:
+        RAILS_VERSION: ${{ inputs.rails-version }}
+        SOLIDUS_BRANCH: ${{ inputs.solidus-branch }}
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: true
+        cache-version: ${{ inputs.rails-version }}-${{ inputs.solidus-branch }}-{{ inputs.database }}-{{ inputs.ruby-version }}
+        rubygems: "latest"
+    - name: Restore apt cache
+      id: apt-cache
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/apt/cache
+        key: ${{ runner.os }}-apt-${{ inputs.database }}
+        restore-keys: |
+          ${{ runner.os }}-apt-
+    - name: Install libvips
+      shell: bash
+      run: |
+        mkdir -p /home/runner/apt/cache
+        sudo apt update -qq
+        sudo apt install -qq --fix-missing libvips -o dir::cache::archives="/home/runner/apt/cache"
+        sudo chown -R runner /home/runner/apt/cache
+    - name: Install Postgres headers
+      if: inputs.database == 'postgresql'
+      shell: bash
+      run: |
+        mkdir -p /home/runner/apt/cache
+        sudo apt update -qq
+        sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
+        sudo chown -R runner /home/runner/apt/cache
+    - name: Install MariaDB headers
+      if: inputs.database == 'mariadb'
+      shell: bash
+      run: |
+        mkdir -p /home/runner/apt/cache
+        sudo apt update -qq
+        sudo apt install -qq --fix-missing libmysqlclient-dev -o dir::cache::archives="/home/runner/apt/cache"
+        sudo chown -R runner /home/runner/apt/cache
+    - name: Run tests
+      shell: bash
+      env:
+        RAILS_VERSION: ${{ inputs.rails-version }}
+        SOLIDUS_BRANCH: ${{ inputs.solidus-branch }}
+      run: |
+        bundle exec rake
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: Screenshots
+        path: |
+          spec/dummy/tmp/capybara
+          spec/dummy/tmp/screenshots

--- a/action.yml
+++ b/action.yml
@@ -11,32 +11,13 @@ inputs:
     required: true
     default: main
   database:
-    description: Database to use. sqlite3, postgresql, or mariadb
+    description: Database to use. sqlite, postgresql, mysql, or mariadb
     required: true
-    default: sqlite3
+    default: sqlite
   ruby-version:
     description: Ruby version to use
     required: true
     default: "3.3"
-
-services:
-  postgres:
-    image: postgres:latest
-    env:
-      POSTGRES_USER: solidus_user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: solidus_extension_test
-    ports: ["5432:5432"]
-    options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-  mariadb:
-    image: mariadb:latest
-    ports: ["3307:3306"]
-    env:
-      MARIADB_USER: solidus_user
-      MARIADB_PASSWORD: password
-      MARIADB_DATABASE: solidus_extension_test
-      MARIADB_ROOT_PASSWORD: password
-    options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=5
 
 runs:
   using: "composite"
@@ -45,6 +26,9 @@ runs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       env:
+        DB: ${{ inputs.database == 'mariadb' && 'mysql' || inputs.database }}
+        DB_HOST: 127.0.0.1
+        DB_USERNAME: ${{ inputs.database == 'postgresql' && 'postgres' || 'root' }}
         RAILS_VERSION: ${{ inputs.rails-version }}
         SOLIDUS_BRANCH: ${{ inputs.solidus-branch }}
       with:
@@ -75,8 +59,8 @@ runs:
         sudo apt update -qq
         sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
         sudo chown -R runner /home/runner/apt/cache
-    - name: Install MariaDB headers
-      if: inputs.database == 'mariadb'
+    - name: Install MySQL/MariaDB headers
+      if: inputs.database == 'mysql' || inputs.database == 'mariadb'
       shell: bash
       run: |
         mkdir -p /home/runner/apt/cache
@@ -86,6 +70,9 @@ runs:
     - name: Run tests
       shell: bash
       env:
+        DB: ${{ inputs.database == 'mariadb' && 'mysql' || inputs.database }}
+        DB_HOST: 127.0.0.1
+        DB_USERNAME: ${{ inputs.database == 'postgresql' && 'postgres' || 'root' }}
         RAILS_VERSION: ${{ inputs.rails-version }}
         SOLIDUS_BRANCH: ${{ inputs.solidus-branch }}
       run: |


### PR DESCRIPTION
## Summary

GitHub composite actions do not
support starting services. The calling
workflow needs to handle this.

Currently all our extensions that test
multiple database actually test with
SQLite all the time.

Expose necessary ENV vars for testing
MySQL and PostgreSQL on GitHub actions.

Adding examples and more documentation
to README. We now need to update all
extensions that use this action manually

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
