### PR TITLE
feat: Add reusable workflow for extension testing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,6 @@ jobs:
             ruby_version: "3.1"
           - solidus_branch: "v4.4"
             rails_version: "8.0"
-          - database: "mysql" # https://github.com/rails/rails/issues/53673
-            rails_version: "8.0"
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,74 @@
+name: Test Solidus Extension
+
+on:
+  workflow_call:
+    inputs:
+      rails_versions:
+        description: 'Rails versions to test (JSON array)'
+        type: string
+        default: '["8.0", "7.2"]'
+      ruby_versions:
+        description: 'Ruby versions to test (JSON array)'
+        type: string
+        default: '["3.4"]'
+      solidus_branches:
+        description: 'Solidus branches to test (JSON array)'
+        type: string
+        default: '["v4.6", "v4.5"]'
+      databases:
+        description: 'Databases to test (JSON array): postgresql, mysql, sqlite'
+        type: string
+        default: '["postgresql", "mysql", "sqlite"]'
+
+jobs:
+  Extension:
+    name: Solidus ${{ matrix.solidus_branch }}, Rails ${{ matrix.rails_version }} and Ruby ${{ matrix.ruby_version }} on ${{ matrix.database }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rails_version: ${{ fromJSON(inputs.rails_versions) }}
+        ruby_version: ${{ fromJSON(inputs.ruby_versions) }}
+        solidus_branch: ${{ fromJSON(inputs.solidus_branches) }}
+        database: ${{ fromJSON(inputs.databases) }}
+        exclude:
+          - solidus_branch: "v4.5"
+            ruby_version: "3.1"
+          - solidus_branch: "v4.6"
+            ruby_version: "3.1"
+          - solidus_branch: "v4.4"
+            rails_version: "8.0"
+          - database: "mysql" # https://github.com/rails/rails/issues/53673
+            rails_version: "8.0"
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 5432:5432
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run extension tests
+        uses: solidusio/test-solidus-extension@support-testings-dbs
+        with:
+          database: ${{ matrix.database }}
+          rails-version: ${{ matrix.rails_version }}
+          ruby-version: ${{ matrix.ruby_version }}
+          solidus-branch: ${{ matrix.solidus_branch }}

--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ The action automatically sets the correct `DB_USERNAME` based on the database:
 
 Configure your database services with passwordless access for simplicity (see example below).
 
-> [!WARNING]
-> Rails 8.0 has a [known issue](https://github.com/rails/rails/issues/53673) with MySQL/MariaDB that causes empty `Mysql2::Error` messages. Until a fix is released, exclude the `mariadb` + Rails 8.0 combination from your test matrix.
-
 #### Example Configuration
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,53 @@
 # Test Solidus Extension GitHub action
 
-A GitHub action for testing Solidus extensions
+GitHub actions and workflows for testing Solidus extensions.
 
-## Inputs
+## Usage
+
+### Reusable Workflow (Recommended)
+
+The simplest way to test your extension. The reusable workflow handles database services and provides a sensible default test matrix:
+
+```yaml
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  Test:
+    uses: solidusio/test-solidus-extension/.github/workflows/test.yml@main
+```
+
+#### Inputs
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `rails_versions` | Rails versions (JSON array) | `["8.0", "7.2"]` |
+| `ruby_versions` | Ruby versions (JSON array) | `["3.4"]` |
+| `solidus_branches` | Solidus branches (JSON array) | `["v4.6", "v4.5"]` |
+| `databases` | Databases (JSON array) | `["postgresql", "mysql", "sqlite"]` |
+
+#### Custom Matrix
+
+Override any input to customize the test matrix:
+
+```yaml
+jobs:
+  test:
+    uses: solidusio/test-solidus-extension/.github/workflows/test.yml@main
+    with:
+      rails_versions: '["7.2"]'
+      databases: '["postgresql", "sqlite"]'
+```
+
+### Composite Action
+
+For full control over your workflow, use the composite action directly. This requires you to define database services yourself.
+
+#### Inputs
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
@@ -11,13 +56,13 @@ A GitHub action for testing Solidus extensions
 | `solidus-branch` | Solidus branch to use | Yes | `main` |
 | `database` | Database to use (`sqlite`, `postgresql`, `mysql`, or `mariadb`) | Yes | `sqlite` |
 
-## Database Services
+#### Database Services
 
-This is a composite GitHub Action, which means it **cannot define services directly**. If you need to test against PostgreSQL or MySQL/MariaDB, you must define the database service in your workflow file.
+The composite GitHub Action **cannot define services directly**. If you need to test against PostgreSQL or MySQL/MariaDB, you must define the database service in your workflow file.
 
 The action will install the necessary database client libraries automatically based on the `database` input.
 
-### Database Credentials
+#### Database Credentials
 
 The action automatically sets the correct `DB_USERNAME` based on the database:
 
@@ -29,7 +74,7 @@ Configure your database services with passwordless access for simplicity (see ex
 > [!WARNING]
 > Rails 8.0 has a [known issue](https://github.com/rails/rails/issues/53673) with MySQL/MariaDB that causes empty `Mysql2::Error` messages. Until a fix is released, exclude the `mariadb` + Rails 8.0 combination from your test matrix.
 
-## Example configuration
+#### Example Configuration
 
 ```yaml
 name: Test


### PR DESCRIPTION
## Summary

Add a reusable workflow that handles database services (PostgreSQL, MySQL)
so extensions don't need to define them manually. The workflow accepts
individual inputs for `rails_versions`, `ruby_versions`, `solidus_branches`,
and `databases` with sensible defaults.

This provides a simpler alternative to the composite action while
maintaining backwards compatibility.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
